### PR TITLE
Remove error if page content is empty (a parent page)

### DIFF
--- a/classes/DropCaps.php
+++ b/classes/DropCaps.php
@@ -10,6 +10,7 @@
 
 namespace Grav\Plugin;
 
+use DOMDocument;
 use Grav\Common\GravTrait;
 
 /**

--- a/classes/DropCaps.php
+++ b/classes/DropCaps.php
@@ -118,9 +118,8 @@ class DropCaps
    */
   protected function insertDropCap($content)
   {
-    // Extract first few letters from paragraph and normalize them
+    // Extract first few letters from paragraph
     $chunk = mb_substr($content, 0, min(8, mb_strlen($content)), 'UTF-8');
-    $chunk = iconv('UTF-8', 'ASCII//TRANSLIT', $chunk);
 
     // We're looking for the first paragraph tag followed by a
     // capital letter

--- a/dropcaps.php
+++ b/dropcaps.php
@@ -105,10 +105,12 @@ class DropCapsPlugin extends Plugin
       // Get content
       $content = $page->getRawContent();
 
-      // Insert DropCap and save modified page content
-      $page->setRawContent(
-        $this->init()->process($content, $config)
-      );
+      if($content){
+          // Insert DropCap and save modified page content
+          $page->setRawContent(
+              $this->init()->process($content, $config)
+          );
+      }
     }
   }
 


### PR DESCRIPTION
When updating to PHP8 an error is thrown if the content of a page is empty. To avoid this I added an if statement